### PR TITLE
failing test case for minify js bug

### DIFF
--- a/js/js_test.go
+++ b/js/js_test.go
@@ -35,6 +35,7 @@ func TestJS(t *testing.T) {
 		{"+\n\"\"", "+\"\""},
 		{"a + ++b", "a+ ++b"},                                          // JSMin caution
 		{"var a=/\\s?auto?\\s?/i\nvar", "var a=/\\s?auto?\\s?/i\nvar"}, // #14
+	        {"}\n'use strict';", "}\n'use strict;"},
 	}
 
 	m := minify.New()


### PR DESCRIPTION
Just run into this problem using minify on some javascript that looked like this:
```
[...]
}
'use strict';
[...]
```
minify removes the newline (outputs: `}'use strict';`) which results in broken javascript.