### PR TITLE
Handling hsla colors with 0%

### DIFF
--- a/css/css.go
+++ b/css/css.go
@@ -447,10 +447,10 @@ func (c *cssMinifier) shortenToken(prop css.Hash, tt css.TokenType, data []byte)
 		}
 		dim := data[n:]
 		data = minify.Number(data[:n], c.o.Decimals)
-		if len(data) != 1 || data[0] != '0' {
-			if tt == css.PercentageToken {
+		if tt == css.PercentageToken {
+			if len(data) != 1 {
 				data = append(data, '%')
-			} else if tt == css.DimensionToken {
+			} else if tt == css.DimensionToken && (len(data) != 1 || (data[0] != '0')) {
 				parse.ToLower(dim)
 				data = append(data, dim...)
 			}

--- a/css/css_test.go
+++ b/css/css_test.go
@@ -72,6 +72,8 @@ func TestCSSInline(t *testing.T) {
 		{"color: rgba(255,0,0,0.5);", "color:rgba(255,0,0,.5)"},
 		{"color: rgba(255,0,0,-1);", "color:transparent"},
 		{"color: hsl(0,100%,50%);", "color:red"},
+		{"color: hsl(0,0%,10%);", "color:hsl(0,0%,10%)"},
+		{"color: hsla(0,100%,0%,1);", "color:hsl(0,100%,0%)"},
 		{"color: hsla(1,2%,3%,1);", "color:#080807"},
 		{"color: hsla(1,2%,3%,0);", "color:transparent"},
 		{"color: hsl(48,100%,50%);", "color:#fc0"},


### PR DESCRIPTION
According to [w3.org](https://www.w3.org/TR/css3-color/#hsla-color) hsl/hsla colors should have % sign in parameters 2 and 3.