### PR TITLE
Use spf13/pflag for flags

### DIFF
--- a/cmd/minify/main.go
+++ b/cmd/minify/main.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/matryer/try"
-	flag "github.com/ogier/pflag"
+	flag "github.com/spf13/pflag"
 	min "github.com/tdewolff/minify"
 	"github.com/tdewolff/minify/css"
 	"github.com/tdewolff/minify/html"


### PR DESCRIPTION
ogier/pflag had have no changes changes since 29 January. spf13/pflag is
always changed and improved.

And also spf13/pflag is faster as you can see in benchmarks:
```
benchmark            old ns/op     new ns/op     delta
BenchmarkFlags-4     11295         7378          -34.68%

benchmark            old allocs     new allocs     delta
BenchmarkFlags-4     51             25             -50.98%

benchmark            old bytes     new bytes     delta
BenchmarkFlags-4     3588          4378          +22.02%
```