### PR TITLE
js: Newline before string is as significant as before other literals

### DIFF
--- a/js/js.go
+++ b/js/js.go
@@ -59,7 +59,7 @@ func (o *Minifier) Minify(_ *minify.M, w io.Writer, r io.Reader, _ map[string]st
 		} else {
 			first := data[0]
 			if (prev == js.IdentifierToken || prev == js.NumericToken || prev == js.PunctuatorToken || prev == js.StringToken || prev == js.RegexpToken) &&
-				(tt == js.IdentifierToken || tt == js.NumericToken || tt == js.PunctuatorToken || tt == js.RegexpToken) {
+				(tt == js.IdentifierToken || tt == js.NumericToken || tt == js.StringToken || tt == js.PunctuatorToken || tt == js.RegexpToken) {
 				if lineTerminatorQueued && (prev != js.PunctuatorToken || prevLast == '}' || prevLast == ']' || prevLast == ')' || prevLast == '+' || prevLast == '-' || prevLast == '"' || prevLast == '\'') &&
 					(tt != js.PunctuatorToken || first == '{' || first == '[' || first == '(' || first == '+' || first == '-' || first == '!' || first == '~') {
 					if _, err := w.Write(newlineBytes); err != nil {

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -23,7 +23,7 @@ func TestJS(t *testing.T) {
 		{"a\n\nb", "a\nb"},
 		{"a// comment\nb", "a\nb"},
 		{"''\na", "''\na"},
-		{"''\n''", "''''"},
+		{"''\n''", "''\n''"},
 		{"]\n0", "]\n0"},
 		{"a\n{", "a\n{"},
 		{";\na", ";a"},
@@ -31,7 +31,7 @@ func TestJS(t *testing.T) {
 		{"}\na", "}\na"},
 		{"+\na", "+\na"},
 		{"+\n(", "+\n("},
-		{"+\n\"\"", "+\"\""},
+		{"+\n\"\"", "+\n\"\""},
 		{"a + ++b", "a+ ++b"},                                          // JSMin caution
 		{"var a=/\\s?auto?\\s?/i\nvar", "var a=/\\s?auto?\\s?/i\nvar"}, // #14
 		{"var a=0\n!function(){}", "var a=0\n!function(){}"},           // #107


### PR DESCRIPTION
In particular, test that was checking `''\n''` -> `''''` was incorrect.

Fixes two more files found in #132