### PR TITLE
fix CSS url() with whitespace

### DIFF
--- a/css/css.go
+++ b/css/css.go
@@ -541,7 +541,7 @@ func (c *cssMinifier) shortenToken(prop css.Hash, tt css.TokenType, data []byte)
 	} else if tt == css.URLToken {
 		parse.ToLower(data[:3])
 		if len(data) > 10 {
-			uri := data[4 : len(data)-1]
+			uri := parse.TrimWhitespace(data[4 : len(data)-1])
 			delim := byte('"')
 			if uri[0] == '\'' || uri[0] == '"' {
 				delim = uri[0]

--- a/css/css_test.go
+++ b/css/css_test.go
@@ -106,6 +106,7 @@ func TestCSSInline(t *testing.T) {
 		{"margin: 0em;", "margin:0"},
 		{"font-family:'Arial', 'Times New Roman';", "font-family:arial,times new roman"},
 		{"background:url('http://domain.com/image.png');", "background:url(http://domain.com/image.png)"},
+		{"background:url( 'http://domain.com/image.png' );", "background:url(http://domain.com/image.png)"},
 		{"filter: progid : DXImageTransform.Microsoft.BasicImage(rotation=1);", "filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1)"},
 		{"filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);", "filter:alpha(opacity=0)"},
 		{"content: \"a\\\nb\";", "content:\"ab\""},


### PR DESCRIPTION
[The spec](https://www.w3.org/TR/CSS2/syndata.html#uri) says:

> The format of a URI value is 'url(' followed by optional white space followed by an optional single quote (') or double quote (") character followed by the URI itself, followed by an optional single quote (') or double quote (") character followed by optional white space followed by ')'.

Currently the minifier transforms `url(   '/path'   )` into `url("   '/path'   ")`.  
This PR fixes that.