### PR TITLE
fix panic for html KeepConditionalComments

### DIFF
--- a/html/html.go
+++ b/html/html.go
@@ -80,19 +80,24 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, _ map[string]st
 				return err
 			}
 		case html.CommentToken:
-			if o.KeepConditionalComments && len(t.Text) > 6 && (bytes.HasPrefix(t.Text, []byte("[if ")) || bytes.Equal(t.Text, []byte("[endif]"))) {
+			if o.KeepConditionalComments && len(t.Text) > 6 && (bytes.HasPrefix(t.Text, []byte("[if ")) || bytes.Equal(t.Text, []byte("[endif]")) || bytes.Equal(t.Text, []byte("<![endif]"))) {
 				// [if ...] is always 7 or more characters, [endif] is only encountered for downlevel-revealed
 				// see https://msdn.microsoft.com/en-us/library/ms537512(v=vs.85).aspx#syntax
 				if bytes.HasPrefix(t.Data, []byte("<!--[if ")) { // downlevel-hidden
 					begin := bytes.IndexByte(t.Data, '>') + 1
 					end := len(t.Data) - len("<![endif]-->")
-					if _, err := w.Write(t.Data[:begin]); err != nil {
-						return err
-					}
-					if err := o.Minify(m, w, buffer.NewReader(t.Data[begin:end]), nil); err != nil {
-						return err
-					}
-					if _, err := w.Write(t.Data[end:]); err != nil {
+
+					if begin < end {
+					    if _, err := w.Write(t.Data[:begin]); err != nil {
+						    return err
+					    }
+					    if err := o.Minify(m, w, buffer.NewReader(t.Data[begin:end]), nil); err != nil {
+						    return err
+					    }
+					    if _, err := w.Write(t.Data[end:]); err != nil {
+						    return err
+					    }
+					} else if _, err := w.Write(t.Data); err != nil { // downlevel-hidden
 						return err
 					}
 				} else if _, err := w.Write(t.Data); err != nil { // downlevel-revealed


### PR DESCRIPTION
fix panic for html KeepConditionalComments [see](https://www.emailonacid.com/blog/article/email-development/prevent-ie-edge-meta-tag-from-breaking-images-in-live-mail)
```
<!--[if !mso]><!-->
<meta http-equiv="X-UA-Compatible" content="IE=edge">
<!--<![endif]-->
```

