### PR TITLE
Fix ASI behaviour for template literals

### DIFF
--- a/js/js.go
+++ b/js/js.go
@@ -72,8 +72,8 @@ func (o *Minifier) Minify(_ *minify.M, w io.Writer, r io.Reader, _ map[string]st
 			}
 		} else {
 			first := data[0]
-			if (prev == js.IdentifierToken || prev == js.NumericToken || prev == js.PunctuatorToken || prev == js.StringToken || prev == js.RegexpToken) &&
-				(tt == js.IdentifierToken || tt == js.NumericToken || tt == js.StringToken || tt == js.PunctuatorToken || tt == js.RegexpToken) {
+			if (prev == js.IdentifierToken || prev == js.NumericToken || prev == js.PunctuatorToken || prev == js.StringToken || prev == js.TemplateToken || prev == js.RegexpToken) &&
+				(tt == js.IdentifierToken || tt == js.NumericToken || tt == js.StringToken || tt == js.TemplateToken || tt == js.PunctuatorToken || tt == js.RegexpToken) {
 				if lineTerminatorQueued && (prev != js.PunctuatorToken || prevLast == '}' || prevLast == ']' || prevLast == ')' || prevLast == '+' || prevLast == '-' || prevLast == '"' || prevLast == '\'') &&
 					(tt != js.PunctuatorToken || first == '{' || first == '[' || first == '(' || first == '+' || first == '-' || first == '!' || first == '~') {
 					if _, err := w.Write(newlineBytes); err != nil {

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -42,6 +42,10 @@ func TestJS(t *testing.T) {
 		{"a\n~b", "a\n~b"},                                             // #132
 		{"x / /\\d+/.exec(s)[0]", "x/ /\\d+/.exec(s)[0]"},              // #183
 
+		{"function(){}\n`string`", "function(){}\n`string`"}, // #181
+		{"false\n`string`", "false\n`string`"},               // #181
+		{"`string`\nwhatever()", "`string`\nwhatever()"},     // #181
+
 		{"x+/**/++y", "x+ ++y"},                          // #185
 		{"x+\n++y", "x+\n++y"},                           // #185
 		{"f()/*!com\nment*/g()", "f()/*!com\nment*/g()"}, // #185


### PR DESCRIPTION
Fixes #181

---

I basically added conditions for template literals in these two conditions with same conditions as for StringLiteral.

What still worries me though is that there is one more branch below where StringLiteral is involved, but I'm not sure why it's there, and it's not covered by any tests (if I remove StringLiteral from that condition, all tests still pass).
