### PR TITLE
html: Add `KeepInlineSvg` option

### DIFF
--- a/cmd/minify/main.go
+++ b/cmd/minify/main.go
@@ -103,6 +103,7 @@ func main() {
 	flag.BoolVar(&htmlMinifier.KeepDocumentTags, "html-keep-document-tags", false, "Preserve html, head and body tags")
 	flag.BoolVar(&htmlMinifier.KeepEndTags, "html-keep-end-tags", false, "Preserve all end tags")
 	flag.BoolVar(&htmlMinifier.KeepWhitespace, "html-keep-whitespace", false, "Preserve whitespace characters but still collapse multiple into one")
+	flag.BoolVar(&htmlMinifier.KeepInlineSvg, "html-keep-inline-svg", false, "Preserve inline svg tags in html file")
 	flag.IntVar(&svgMinifier.Decimals, "svg-decimals", -1, "Number of decimals to preserve in numbers, -1 is all")
 	flag.BoolVar(&xmlMinifier.KeepWhitespace, "xml-keep-whitespace", false, "Preserve whitespace characters but still collapse multiple into one")
 	flag.Parse()

--- a/cmd/minify/main.go
+++ b/cmd/minify/main.go
@@ -45,14 +45,15 @@ var filetypeMime = map[string]string{
 }
 
 var (
-	hidden    bool
-	list      bool
-	m         *min.M
-	pattern   *regexp.Regexp
-	recursive bool
-	verbose   bool
-	version   bool
-	watch     bool
+	hidden              bool
+	list                bool
+	m                   *min.M
+	pattern             *regexp.Regexp
+	recursive           bool
+	svgMinifierDisabled bool
+	verbose             bool
+	version             bool
+	watch               bool
 )
 
 type task struct {
@@ -103,7 +104,7 @@ func main() {
 	flag.BoolVar(&htmlMinifier.KeepDocumentTags, "html-keep-document-tags", false, "Preserve html, head and body tags")
 	flag.BoolVar(&htmlMinifier.KeepEndTags, "html-keep-end-tags", false, "Preserve all end tags")
 	flag.BoolVar(&htmlMinifier.KeepWhitespace, "html-keep-whitespace", false, "Preserve whitespace characters but still collapse multiple into one")
-	flag.BoolVar(&htmlMinifier.KeepInlineSvg, "html-keep-inline-svg", false, "Preserve inline svg tags in html file")
+	flag.BoolVar(&svgMinifierDisabled, "svg-minifier-disabled", false, "Disable SVG Minifier")
 	flag.IntVar(&svgMinifier.Decimals, "svg-decimals", -1, "Number of decimals to preserve in numbers, -1 is all")
 	flag.BoolVar(&xmlMinifier.KeepWhitespace, "xml-keep-whitespace", false, "Preserve whitespace characters but still collapse multiple into one")
 	flag.Parse()
@@ -186,7 +187,9 @@ func main() {
 	m.Add("text/css", cssMinifier)
 	m.Add("text/html", htmlMinifier)
 	m.Add("text/javascript", jsMinifier)
-	m.Add("image/svg+xml", svgMinifier)
+	if !svgMinifierDisabled {
+		m.Add("image/svg+xml", svgMinifier)
+	}
 	m.AddRegexp(regexp.MustCompile("[/+]json$"), jsonMinifier)
 	m.AddRegexp(regexp.MustCompile("[/+]xml$"), xmlMinifier)
 

--- a/html/html.go
+++ b/html/html.go
@@ -38,6 +38,7 @@ type Minifier struct {
 	KeepDocumentTags        bool
 	KeepEndTags             bool
 	KeepWhitespace          bool
+	KeepInlineSvg           bool
 }
 
 // Minify minifies HTML data, it reads from r and writes to w.
@@ -100,11 +101,17 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, _ map[string]st
 				}
 			}
 		case html.SvgToken:
-			if err := m.MinifyMimetype(svgMimeBytes, w, buffer.NewReader(t.Data), nil); err != nil {
-				if err != minify.ErrNotExist {
+			if o.KeepInlineSvg {
+				if _, err := w.Write(t.Data); err != nil {
 					return err
-				} else if _, err := w.Write(t.Data); err != nil {
-					return err
+				}
+			} else {
+				if err := m.MinifyMimetype(svgMimeBytes, w, buffer.NewReader(t.Data), nil); err != nil {
+					if err != minify.ErrNotExist {
+						return err
+					} else if _, err := w.Write(t.Data); err != nil {
+						return err
+					}
 				}
 			}
 		case html.MathToken:

--- a/html/html.go
+++ b/html/html.go
@@ -38,7 +38,6 @@ type Minifier struct {
 	KeepDocumentTags        bool
 	KeepEndTags             bool
 	KeepWhitespace          bool
-	KeepInlineSvg           bool
 }
 
 // Minify minifies HTML data, it reads from r and writes to w.
@@ -101,17 +100,12 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, _ map[string]st
 				}
 			}
 		case html.SvgToken:
-			if o.KeepInlineSvg {
-				if _, err := w.Write(t.Data); err != nil {
+			if err := m.MinifyMimetype(svgMimeBytes, w, buffer.NewReader(t.Data), nil); err != nil {
+				if err != minify.ErrNotExist {
 					return err
-				}
-			} else {
-				if err := m.MinifyMimetype(svgMimeBytes, w, buffer.NewReader(t.Data), nil); err != nil {
-					if err != minify.ErrNotExist {
-						return err
-					} else if _, err := w.Write(t.Data); err != nil {
-						return err
-					}
+				} else if _, err := w.Write(t.Data); err != nil {
+					return err
+
 				}
 			}
 		case html.MathToken:

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -172,6 +172,26 @@ func TestHTMLKeepEndTags(t *testing.T) {
 	}
 }
 
+func TestHTMLKeepInlineSvg(t *testing.T) {
+	htmlTests := []struct {
+		html     string
+		expected string
+	}{
+		{`<svg> <g id="parent"> <g id="child1"></g> <g id="child"></g> </g> </svg>`, `<svg> <g id="parent"> <g id="child1"></g> <g id="child"></g> </g> </svg>`},
+	}
+
+	m := minify.New()
+	htmlMinifier := &Minifier{KeepInlineSvg: true}
+	m.AddFunc("image/svg+xml", svg.Minify)
+	for _, tt := range htmlTests {
+		t.Run(tt.html, func(t *testing.T) {
+			r := bytes.NewBufferString(tt.html)
+			w := &bytes.Buffer{}
+			err := htmlMinifier.Minify(m, w, r, nil)
+			test.Minify(t, tt.html, err, w.String(), tt.expected)
+		})
+	}
+}
 func TestHTMLKeepConditionalComments(t *testing.T) {
 	htmlTests := []struct {
 		html     string

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -172,26 +172,6 @@ func TestHTMLKeepEndTags(t *testing.T) {
 	}
 }
 
-func TestHTMLKeepInlineSvg(t *testing.T) {
-	htmlTests := []struct {
-		html     string
-		expected string
-	}{
-		{`<svg> <g id="parent"> <g id="child1"></g> <g id="child"></g> </g> </svg>`, `<svg> <g id="parent"> <g id="child1"></g> <g id="child"></g> </g> </svg>`},
-	}
-
-	m := minify.New()
-	htmlMinifier := &Minifier{KeepInlineSvg: true}
-	m.AddFunc("image/svg+xml", svg.Minify)
-	for _, tt := range htmlTests {
-		t.Run(tt.html, func(t *testing.T) {
-			r := bytes.NewBufferString(tt.html)
-			w := &bytes.Buffer{}
-			err := htmlMinifier.Minify(m, w, r, nil)
-			test.Minify(t, tt.html, err, w.String(), tt.expected)
-		})
-	}
-}
 func TestHTMLKeepConditionalComments(t *testing.T) {
 	htmlTests := []struct {
 		html     string


### PR DESCRIPTION
I admit that I need the option for only a few edge cases finally, but it may be worth for some people until implementation of svg minification will have been done.