### PR TITLE
Goreleaser: Turn off CGO

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,8 @@ builds:
     - binary: minify
       main: ./cmd/minify/
       ldflags: -s -w -X main.Version={{.Version}} -X main.Commit={{.Commit}} -X main.Date={{.Date}}
+      env:
+          - CGO_ENABLED=0
       goos:
           - windows
           - linux


### PR DESCRIPTION
I can't run the released Linx AMD-64 version of minify in an Alpine Docker image. I believe the reason is that it dynamically links to a C header that Alpine doesn't have. When I run `file` on minify 2.3.4, this is what I get:

```
$ file minify
minify: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, stripped
```

My proposed fix is to turn off CGO in go releaser.