### PR TITLE
Add option (svg): KeepEmptyContainers

### DIFF
--- a/cmd/minify/main.go
+++ b/cmd/minify/main.go
@@ -104,6 +104,7 @@ func main() {
 	flag.BoolVar(&htmlMinifier.KeepEndTags, "html-keep-end-tags", false, "Preserve all end tags")
 	flag.BoolVar(&htmlMinifier.KeepWhitespace, "html-keep-whitespace", false, "Preserve whitespace characters but still collapse multiple into one")
 	flag.IntVar(&svgMinifier.Decimals, "svg-decimals", -1, "Number of decimals to preserve in numbers, -1 is all")
+	flag.BoolVar(&svgMinifier.KeepEmptyContainers, "svg-keep-empty-containers", false, "Preserve all container tags even if they are empty")
 	flag.BoolVar(&xmlMinifier.KeepWhitespace, "xml-keep-whitespace", false, "Preserve whitespace characters but still collapse multiple into one")
 	flag.Parse()
 	rawInputs := flag.Args()

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -33,7 +33,8 @@ var DefaultMinifier = &Minifier{Decimals: -1}
 
 // Minifier is an SVG minifier.
 type Minifier struct {
-	Decimals int
+	Decimals            int
+	KeepEmptyContainers bool
 }
 
 // Minify minifies SVG data, it reads from r and writes to w.
@@ -113,7 +114,7 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, _ map[string]st
 			}
 		case xml.StartTagToken:
 			tag = t.Hash
-			if containerTagMap[tag] { // skip empty containers
+			if !o.KeepEmptyContainers && containerTagMap[tag] { // skip empty containers
 				i := 0
 				for {
 					next := tb.Peek(i)

--- a/svg/svg_test.go
+++ b/svg/svg_test.go
@@ -125,6 +125,26 @@ func TestSVGDecimals(t *testing.T) {
 	}
 }
 
+func TestKeepEmptyContainers(t *testing.T) {
+	var svgTests = []struct {
+		svg      string
+		expected string
+	}{
+		{`<svg> <g id="parent"> <g id="child1"></g> <g id="child2"></g> </g> </svg>`, `<svg><g id="parent"><g id="child1"/><g id="child2"/></g></svg>`},
+	}
+
+	m := minify.New()
+	o := &Minifier{KeepEmptyContainers: true}
+	for _, tt := range svgTests {
+		t.Run(tt.svg, func(t *testing.T) {
+			r := bytes.NewBufferString(tt.svg)
+			w := &bytes.Buffer{}
+			err := o.Minify(m, w, r, nil)
+			test.Minify(t, tt.svg, err, w.String(), tt.expected)
+		})
+	}
+}
+
 func TestReaderErrors(t *testing.T) {
 	r := test.NewErrorReader(0)
 	w := &bytes.Buffer{}


### PR DESCRIPTION
Related #190

Currently, `minify` deletes empty container tags in SVG.
There is a risk that the spec may lead to unexpected effects of JS/CSS on SVG.

This PR add an option to keep/delete empty containers in SVG.