### PR TITLE
Add option (html): KeepEsiIncludeComments

### DIFF
--- a/html/html.go
+++ b/html/html.go
@@ -34,6 +34,7 @@ var DefaultMinifier = &Minifier{}
 // Minifier is an HTML minifier.
 type Minifier struct {
 	KeepConditionalComments bool
+	KeepEsiIncludeComments	bool
 	KeepDefaultAttrVals     bool
 	KeepDocumentTags        bool
 	KeepEndTags             bool
@@ -80,6 +81,11 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, _ map[string]st
 				return err
 			}
 		case html.CommentToken:
+			if o.KeepEsiIncludeComments && bytes.HasPrefix(t.Text, []byte("esi")) && bytes.Contains(t.Text, []byte("esi:include")) {
+				if _, err := w.Write(t.Data); err != nil {
+					return err
+				}
+			}
 			if o.KeepConditionalComments && len(t.Text) > 6 && (bytes.HasPrefix(t.Text, []byte("[if ")) || bytes.Equal(t.Text, []byte("[endif]")) || bytes.Equal(t.Text, []byte("<![endif]"))) {
 				// [if ...] is always 7 or more characters, [endif] is only encountered for downlevel-revealed
 				// see https://msdn.microsoft.com/en-us/library/ms537512(v=vs.85).aspx#syntax

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -264,6 +264,28 @@ func TestHTMLURL(t *testing.T) {
 	}
 }
 
+func TestHTMLKeepEsiIncludeComments(t *testing.T) {
+	htmlTests := []struct {
+		html     string
+		expected string
+	}{
+		{` <!--esi <esi:include src="https://example.com/" /> --> `, `<!--esi <esi:include src="https://example.com/" /> -->`},
+		{" <!--esi any text\n<esi:include src=\"https://example.com/\" /> --> ", "<!--esi any text\n<esi:include src=\"https://example.com/\" /> -->"},
+	}
+
+	m := minify.New()
+	htmlMinifier := &Minifier{KeepEsiIncludeComments: true}
+	for _, tt := range htmlTests {
+		t.Run(tt.html, func(t *testing.T) {
+			r := bytes.NewBufferString(tt.html)
+			w := &bytes.Buffer{}
+			err := htmlMinifier.Minify(m, w, r, nil)
+			test.Minify(t, tt.html, err, w.String(), tt.expected)
+		})
+	}
+
+}
+
 func TestSpecialTagClosing(t *testing.T) {
 	m := minify.New()
 	m.AddFunc("text/html", Minify)


### PR DESCRIPTION
Currently library removes comments of ESI include.

For example:
```
<!--esi
<p>The full text of the license:</p>
<esi:include src="http://example.com/LICENSE" />
-->
```

[Varnish ESI](https://varnish-cache.org/docs/3.0/tutorial/esi.html#example-esi-remove-and-esi)