### PR TITLE
if html attribute contains go template operands ({{ && }}), ignore it

### DIFF
--- a/html/html.go
+++ b/html/html.go
@@ -337,6 +337,15 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, _ map[string]st
 				htmlEqualIdName := false
 				for {
 					attr := *tb.Shift()
+
+					//ignore {{ .Go .Template .Code }} in attr variables, do not remove quotes or optimize it in any way
+					if len(attr.AttrVal) > 6 && bytes.Contains(attr.AttrVal, []byte("{{")) && bytes.Contains(attr.AttrVal, []byte("}}")) {
+						if _, err := w.Write(attr.Data); err != nil {
+							return err
+						}
+						continue
+					}
+
 					if attr.TokenType != html.AttributeToken {
 						break
 					} else if attr.Text == nil {


### PR DESCRIPTION
Example:
````<img src="/logo.png" Alt="{{.Desc}}" />````

What current minifier does:
````<img src=/logo.png alt={{.Desc}}>````

But if {{.Desc}} contains spaces (ex: "Company logo"), it would broke alt attribute.

This pull requests ignores attribute completely (writes it as is) if {{ and }} are found.

After this pull request code will be minified to:
````<img src=/logo.png Alt="{{.Desc}}">````