### PR TITLE
Remove "convert rect, line, polygon, polyline to path" from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ The SVG minifier uses these minifications:
 - minify colors
 - shorten lengths and numbers and remove default `px` unit
 - shorten `path` data
-- convert `rect`, `line`, `polygon`, `polyline` to `path`
 - use relative or absolute positions in path data whichever is shorter
 
 TODO:


### PR DESCRIPTION
Hi!  Thank you for your clear v2.5.2 release note:

> SVG: don't convert polyline/rect/polygon/line to path, which can break CSS, fixes #260

which helped me solve the mystery why Hugo's go test failed with minify v2.5.2.  It turns out that it was relying on "convert line to path" `<line x1="5" y1="10" x2="20" y2="40"/>` to `<path d="M5 10 20 40z"/>` as a test case, so I'm going to borrow another test case from your svg/svg_test.go.

I noticed README.md still mentions "convert rect, line, polygon, polyline to path", and that actually confused me for a little bit, hence this pull request.

Many thanks!