### PR TITLE
Remove custom entrypoint from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use this image to build the executable
-FROM golang:1.13-alpine AS compiler
+FROM golang:1.16-alpine AS compiler
 
 WORKDIR $GOPATH/src/minify
 COPY . .
@@ -12,5 +12,3 @@ RUN apk add --update --update-cache --no-cache git ca-certificates && \
 FROM alpine:3
 
 COPY --from=compiler /bin/minify /bin/minify
-
-ENTRYPOINT ["/bin/minify"]


### PR DESCRIPTION
This makes it usable in more use cases like CI. minify can be called as `minify` from the shell.

Regarding compatibility with existing configurations: They will break. I'd recommend to create a new tag (maybe `custom-entrypoint`?)on dockerhub for the old Dockerfile and add that version there before pushing the new container to the `latest` tag (currently the only tag you have).

Should not that I'm not an expert regarding docker either, and there probably are use cases where the entry point made sense, but as a general use container I believe it's better to have a standard shell.

Also upgrade Go to 1.16 otherwise compiling fails. If you ever increase the minimum requirements above 1.16 just change `golang:1.16-alpine` to `golang:1.17-alpine` or whatever you need.

closes #387 