### PR TITLE
JSON: add keep numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ The JSON minifier only removes whitespace, which is the only thing that can be l
 Options:
 
 - `Precision` number of significant digits to preserve for numbers, `0` means no trimming
-- `SkipNumbers` do not minify numbers if set to `true`, by default numbers will be minified
+- `KeepNumbers` do not minify numbers if set to `true`, by default numbers will be minified
 
 ## SVG
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ The JSON minifier only removes whitespace, which is the only thing that can be l
 Options:
 
 - `Precision` number of significant digits to preserve for numbers, `0` means no trimming
+- `SkipNumbers` do not minify numbers if set to `true`, by default numbers will be minified
 
 ## SVG
 

--- a/json/json.go
+++ b/json/json.go
@@ -23,7 +23,8 @@ var DefaultMinifier = &Minifier{}
 
 // Minifier is a JSON minifier.
 type Minifier struct {
-	Precision int // number of significant digits
+	SkipNumbers bool // do not minify numbers if set to true
+	Precision   int  // number of significant digits
 }
 
 // Minify minifies JSON data, it reads from r and writes to w.
@@ -61,7 +62,7 @@ func (o *Minifier) Minify(_ *minify.M, w io.Writer, r io.Reader, _ map[string]st
 		}
 		skipComma = gt == json.StartObjectGrammar || gt == json.StartArrayGrammar
 
-		if 0 < len(text) && ('0' <= text[0] && text[0] <= '9' || text[0] == '-') {
+		if !o.SkipNumbers && 0 < len(text) && ('0' <= text[0] && text[0] <= '9' || text[0] == '-') {
 			text = minify.Number(text, o.Precision)
 			if text[0] == '.' {
 				w.Write(zeroBytes)

--- a/json/json.go
+++ b/json/json.go
@@ -23,7 +23,7 @@ var DefaultMinifier = &Minifier{}
 
 // Minifier is a JSON minifier.
 type Minifier struct {
-	SkipNumbers bool // do not minify numbers if set to true
+	KeepNumbers bool // do not minify numbers if set to true
 	Precision   int  // number of significant digits
 }
 
@@ -62,7 +62,7 @@ func (o *Minifier) Minify(_ *minify.M, w io.Writer, r io.Reader, _ map[string]st
 		}
 		skipComma = gt == json.StartObjectGrammar || gt == json.StartArrayGrammar
 
-		if !o.SkipNumbers && 0 < len(text) && ('0' <= text[0] && text[0] <= '9' || text[0] == '-') {
+		if !o.KeepNumbers && 0 < len(text) && ('0' <= text[0] && text[0] <= '9' || text[0] == '-') {
 			text = minify.Number(text, o.Precision)
 			if text[0] == '.' {
 				w.Write(zeroBytes)

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -38,6 +38,35 @@ func TestJSON(t *testing.T) {
 	}
 }
 
+func TestJSON_IgnoreNumbers(t *testing.T) {
+	jsonTests := []struct {
+		json     string
+		expected string
+	}{
+		{"", ""},
+		{"{ \"a\": [1, 2] }", "{\"a\":[1,2]}"},
+		{"[{ \"a\": [{\"x\": null}, true] }]", "[{\"a\":[{\"x\":null},true]}]"},
+		{"{ \"a\": 1, \"b\": 2 }", "{\"a\":1,\"b\":2}"},
+		{"{ \"a\": 1           , \"b\": 2 }", "{\"a\":1,\"b\":2}"},
+		{"1.3e1", "1.3e1"},
+		{"1E+03", "1E+03"},
+		{"0.1", "0.1"},
+		{"-0.1", "-0.1"},
+		{"1.0", "1.0"},
+		{"10000", "10000"},
+	}
+	m := Minifier{SkipNumbers: true}
+	for _, tt := range jsonTests {
+		t.Run(tt.json, func(t *testing.T) {
+			r := bytes.NewBufferString(tt.json)
+			w := &bytes.Buffer{}
+			err := m.Minify(nil, w, r, nil)
+			test.Minify(t, tt.json, err, w.String(), tt.expected)
+		})
+	}
+
+}
+
 func TestReaderErrors(t *testing.T) {
 	r := test.NewErrorReader(0)
 	w := &bytes.Buffer{}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -55,7 +55,7 @@ func TestJSON_IgnoreNumbers(t *testing.T) {
 		{"1.0", "1.0"},
 		{"10000", "10000"},
 	}
-	m := Minifier{SkipNumbers: true}
+	m := Minifier{KeepNumbers: true}
 	for _, tt := range jsonTests {
 		t.Run(tt.json, func(t *testing.T) {
 			r := bytes.NewBufferString(tt.json)


### PR DESCRIPTION
hi @tdewolff, I created this PR relating to our previous discussion in #400. 


I'm proposing a `KeepNumbers` flag in JSON to keep numbers in their original format.

In our workflow, we build rest clients and services in go, and we'd love to minify our requests' json payload; however we would also like to have them being unmarshalled into int64 numbers which we are doing a lot. Having this option to keep numbers in original format is crucial.

Please let me know if you are up for it and if so any additional changes would be required.

Thank you.