### PR TITLE
Generate code coverage 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
   directory: /
   schedule:
     interval: daily
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,5 +21,10 @@ jobs:
     - name: Build
       run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+    - name: Tests with coverage
+      run: go test -race -v -count=1 -coverprofile=coverage.out ./...
+    - name: Upload Code Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        name: codecov
+        fail_ci_if_error: true


### PR DESCRIPTION
This allows the generation of a coverage report and then transmit it to codecov.io so it can analyze it on it's repartition and progression