### PR TITLE
Add html option to keep the forward slash in self closing tags

### DIFF
--- a/html/html_test.go
+++ b/html/html_test.go
@@ -525,3 +525,29 @@ func ExampleMinify_writer() {
 	w.Close()
 	// Output: <h1>Example</h1>
 }
+
+func TestHTMLKeepSelfClosingTags(t *testing.T) {
+	htmlTests := []struct {
+		html     string
+		expected string
+	}{
+		{`<br />`, `<br/>`},
+		{`<br/>`, `<br/>`},
+		{`<img src="example"/>`, `<img src=example/>`},
+		{`<h1><img src="example" alt="example" /></h1>`, `<h1><img src=example alt=example/></h1>`},
+		{`<h1><br /><br /></h1>`, `<h1><br/><br/></h1>`},
+		{`<foo><bar><br /><br /></bar></foo>`, `<foo><bar><br/><br/></bar></foo>`},
+		{`<foo><bar><br /><img src=example /></bar></foo>`, `<foo><bar><br/><img src=example/></bar></foo>`},
+	}
+
+	m := minify.New()
+	htmlMinifier := &Minifier{KeepSelfClosingTags: true}
+	for _, tt := range htmlTests {
+		t.Run(tt.html, func(t *testing.T) {
+			r := bytes.NewBufferString(tt.html)
+			w := &bytes.Buffer{}
+			err := htmlMinifier.Minify(m, w, r, nil)
+			test.Minify(t, tt.html, err, w.String(), tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
Some older HTML clients/rendering engines cannot properly parse tags, which should be self-closing, but don't have the forward slash before the >.
I want to add an option so users of the library can choose to keep the forward slashes in such situations. This change should cause no degradation in functionality.