### PR TITLE
Changed makefile to use Bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=/bin/bash
 NAME=minify
 CMD=./cmd/minify
 TARGETS=linux_amd64 darwin_amd64 freebsd_amd64 netbsd_amd64 openbsd_amd64 windows_amd64


### PR DESCRIPTION
The shebang in a source file does not apply when it is included within another script. This means bash_completion will be interpreted by whichever shell is being used for the makefile, which by default is /bin/sh. On Debian, for example, /bin/sh is dash and so I receive the following error: /bin/sh: 19: cmd/minify/bash_completion: Syntax error: "(" unexpected (expecting "fi").