### PR TITLE
prebuild for arm64 (linux and macos)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 	. cmd/minify/bash_completion
 
 release:
-	#TAG=$(shell git describe --tags --exact-match 2> /dev/null);
+	TAG=$(shell git describe --tags --exact-match 2> /dev/null);
 	if [ "${.SHELLSTATUS}" -eq 0 ]; then \
 		echo "Releasing ${VERSION}"; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/usr/bin/env bash
 NAME=minify
 CMD=./cmd/minify
-TARGETS=linux_amd64 darwin_amd64 freebsd_amd64 netbsd_amd64 openbsd_amd64 windows_amd64
+TARGETS=linux_amd64 linux_arm64 darwin_amd64 darwin_arm64 freebsd_amd64 netbsd_amd64 openbsd_amd64 windows_amd64
 VERSION=`git describe --tags`
 FLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}'" -trimpath
 ENVS=GO111MODULES=on CGO_ENABLED=0
@@ -14,7 +14,7 @@ install:
 	. cmd/minify/bash_completion
 
 release:
-	TAG=$(shell git describe --tags --exact-match 2> /dev/null);
+	#TAG=$(shell git describe --tags --exact-match 2> /dev/null);
 	if [ "${.SHELLSTATUS}" -eq 0 ]; then \
 		echo "Releasing ${VERSION}"; \
 	else \


### PR DESCRIPTION
Many users start to have ARM64 machines but there are no prebuilt binaries for arm64.
This pull request adds the cross compilation flags needed to Makefile to cross compile to ARM64 linux and darwin.

By publishing arm64 prebuilt binaries, the package https://github.com/JoakimCh/tdewolff-minify should work without any further change.

Tested on my machine that all platform were compiled properly in the dist folder when "make release" is executed, both with go 1.18 and 1.17.

![image](https://user-images.githubusercontent.com/6913178/168884730-d8fbf721-c8f4-4087-88b5-3a35f61e9a8a.png)


![image](https://user-images.githubusercontent.com/6913178/168884641-fedcdce2-05e6-4ba0-afd0-b77bc4ef9439.png)
