### PR TITLE
chore: js binding is esm

### DIFF
--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -7,10 +7,10 @@ Make sure to have [Go](https://go.dev/doc/install) installed.
 There are three functions available in JavaScript: configure the minifiers, minify a string, and minify a file. Below an example of their usage:
 
 ```js
-const minify = require('@tdewolff/minify');
+import { config, string, file } from '@tdewolff/minify';
 
 # default config option values
-minify.config({
+config({
     'css-precision': 0,
     'html-keep-comments': false,
     'html-keep-conditional-comments': false,
@@ -29,10 +29,10 @@ minify.config({
     'xml-keep-whitespace': false,
 })
 
-s = minify.string('text/html', '<span style="color:#ff0000;" class="text">Some  text</span>')
+const s = string('text/html', '<span style="color:#ff0000;" class="text">Some  text</span>')
 console.log(s)  // <span style=color:red class=text>Some text</span>
 
-minify.file('text/html', 'example.html', 'example.min.html')  // creates example.min.html
+file('text/html', 'example.html', 'example.min.html')  // creates example.min.html
 ```
 
 ## Mediatypes

--- a/bindings/js/example/example.js
+++ b/bindings/js/example/example.js
@@ -1,8 +1,8 @@
-const minify = require('@tdewolff/minify');  // run: npm i @tdewolff/minify
+import { config, string, file } from '@tdewolff/minify';  // run: npm i @tdewolff/minify
 
-minify.config({'html-keep-document-tags': 0})
+config({'html-keep-document-tags': 0})
 
-s = minify.string("text/html", "<span style=\"color:#ff0000;\">A  phrase</span>");
+s = string("text/html", "<span style=\"color:#ff0000;\">A  phrase</span>");
 console.log(s)
 
-minify.file("text/html", "example.html", "example.min.html");
+file("text/html", "example.html", "example.min.html");

--- a/bindings/js/example/package.json
+++ b/bindings/js/example/package.json
@@ -1,5 +1,6 @@
 {
-  "main": "example.js",
+  "exports": "./example.js",
+  "type": "module",
   "dependencies": {
     "@tdewolff/minify": "^2.11.11"
   }

--- a/bindings/js/index.js
+++ b/bindings/js/index.js
@@ -1,2 +1,10 @@
-module.exports = require('./build/Release/obj.target/minify');
-module.exports.version = require('./package.json').version;
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+// https://nodejs.org/api/esm.html#no-native-module-loading
+export const { string, config, file } = require('./build/Release/obj.target/minify');
+
+// Starting from node 16, json imports have been unflagged
+// import pkg from "./package.json" assert { type: "json" }
+export const version = require('./package.json').version;

--- a/bindings/js/package.json
+++ b/bindings/js/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@tdewolff/minify",
   "version": "2.11.11",
+  "type": "module",
   "author": "Taco de Wolff",
   "license": "MIT",
   "description": "Go minifiers for web formats",
   "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "files": [
     "index.js",
     "binding.gyp",

--- a/bindings/js/test.js
+++ b/bindings/js/test.js
@@ -1,5 +1,5 @@
-const minify = require('./build/Release/obj.target/minify');
+import { config, string } from '@tdewolff/minify';
 
-minify.config({'html-keep-document-tags': 5.0})
+config({'html-keep-document-tags': 5.0})
 
-console.log(minify.string("text/html", "<html><span style=\"color:#ff0000;\">A  phrase</span>"));
+console.log(string("text/html", "<html><span style=\"color:#ff0000;\">A  phrase</span>"));


### PR DESCRIPTION
Was thinking that new projects are better off being esm-only from the beginning, since node is really pushing it too (all their docs are esm first, etc).