### PR TITLE
Fix nodejs binding for macos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,13 @@ updates:
   directory: /
   schedule:
     interval: daily
+- package-ecosystem: npm
+  directory: /bindings/js
+  versioning-strategy: increase
+  schedule:
+    interval: weekly
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    # Check for updates to GitHub Actions every weekday
+    interval: daily

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,10 +35,10 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           working-directory: bindings/js
-        # env:
-        #   CGO_CFLAGS: -mmacosx-version-min=10.13
-        #   CGO_LDFLAGS: -mmacosx-version-min=10.13 
-        #   GOARCH: amd64
+        env:
+          # CGO_CFLAGS: -mmacosx-version-min=10.13
+          # CGO_LDFLAGS: -mmacosx-version-min=10.13 
+          GOARCH: amd64
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,11 +1,9 @@
 name: Nodejs
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  workflow_run:
+    workflows: [Go]
+    types:
+      - completed
 
 jobs:
   test:
@@ -16,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-10
+          - macos-10.15
           - windows-latest
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-10
           - windows-latest
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           # CGO_CFLAGS: -mmacosx-version-min=10.13
           # CGO_LDFLAGS: -mmacosx-version-min=10.13 
-          GOARCH: amd64
+          GOARCH: arm64
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           # CGO_CFLAGS: -mmacosx-version-min=10.13
           # CGO_LDFLAGS: -mmacosx-version-min=10.13 
-          GOARCH: arm64
+          GOARCH: amd64
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,6 +35,10 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           working-directory: bindings/js
+        env:
+          CGO_CFLAGS: -mmacosx-version-min=10.13
+          CGO_LDFLAGS: -mmacosx-version-min=10.13 
+          GOARCH: amd64
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,40 @@
+name: Nodejs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node-version:
+          - 14.x
+          - 16.x
+          - 18.x
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+        with:
+          working-directory: bindings/js
+
+      - name: Test
+        run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,18 +18,12 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        node-version:
-          - 14.x
-          - 16.x
-          - 18.x
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-10.15
+          - macos-latest
           - windows-latest
 
     steps:
@@ -35,6 +35,8 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           working-directory: bindings/js
+        env:
+          LC_VERSION_MIN_MACOSX: 10.13
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -37,7 +37,7 @@ jobs:
         #   working-directory: bindings/js
         run: npm --prefix bindings/js ci
         env:
-          LC_VERSION_MIN_MACOSX: 10.13
+          CXXFLAGS: -mmacosx-version-min=10.13
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,9 +32,10 @@ jobs:
         uses: actions/setup-node@v3
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@v1
-        with:
-          working-directory: bindings/js
+        # uses: bahmutov/npm-install@v1
+        # with:
+        #   working-directory: bindings/js
+        run: npm ci
         env:
           LC_VERSION_MIN_MACOSX: 10.13
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,10 +35,10 @@ jobs:
         uses: bahmutov/npm-install@v1
         with:
           working-directory: bindings/js
-        env:
-          CGO_CFLAGS: -mmacosx-version-min=10.13
-          CGO_LDFLAGS: -mmacosx-version-min=10.13 
-          GOARCH: amd64
+        # env:
+        #   CGO_CFLAGS: -mmacosx-version-min=10.13
+        #   CGO_LDFLAGS: -mmacosx-version-min=10.13 
+        #   GOARCH: amd64
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,7 +35,7 @@ jobs:
         # uses: bahmutov/npm-install@v1
         # with:
         #   working-directory: bindings/js
-        run: npm ci
+        run: npm --prefix bindings/js ci
         env:
           LC_VERSION_MIN_MACOSX: 10.13
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,12 +32,9 @@ jobs:
         uses: actions/setup-node@v3
 
       - name: Install dependencies
-        # uses: bahmutov/npm-install@v1
-        # with:
-        #   working-directory: bindings/js
-        run: npm --prefix bindings/js ci
-        env:
-          CXXFLAGS: -mmacosx-version-min=10.13
+        uses: bahmutov/npm-install@v1
+        with:
+          working-directory: bindings/js
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    if: github.event.workflow_run.conclusion == 'success'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,22 +23,18 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          # - windows-latest
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
-
+        
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
         with:
           working-directory: bindings/js
-        env:
-          # CGO_CFLAGS: -mmacosx-version-min=10.13
-          # CGO_LDFLAGS: -mmacosx-version-min=10.13 
-          GOARCH: amd64
 
       - name: Test
         run: npm --prefix bindings/js test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,14 +1,21 @@
 name: Nodejs
 on:
-  workflow_run:
-    workflows: [Go]
-    types:
-      - completed
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  # it seems this won't work until this file is merged into master
+  # workflow_run:
+  #   workflows: [Go]
+  #   types:
+  #     - completed
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    if: github.event.workflow_run.conclusion == 'success'
+    # if: github.event.workflow_run.conclusion == 'success'
 
     strategy:
       fail-fast: false

--- a/bindings/js/Makefile
+++ b/bindings/js/Makefile
@@ -3,6 +3,7 @@ VERSION=`git describe --tags --abbrev=0 | cut -b 2-`
 
 # Below line is for Mac
 ifeq ($(shell uname -s),Darwin)
+# node-gyp will run c++ with -mmacosx-version-min=10.13, set golang to match this
 export CGO_CFLAGS += -mmacosx-version-min=10.13
 export CGO_LDFLAGS += -mmacosx-version-min=10.13
 endif

--- a/bindings/js/Makefile
+++ b/bindings/js/Makefile
@@ -5,7 +5,7 @@ all: build
 
 # called by node-gyp
 compile:
-	CGO_CFLAGS=-mmacosx-version-min=10.13 CGO_LDFLAGS=-mmacosx-version-min=10.13 GOARCH=amd64 go build -buildmode=c-archive -o minify.a minify.go
+	go build -buildmode=c-archive -o minify.a minify.go
 
 build:
 	go get -u all

--- a/bindings/js/Makefile
+++ b/bindings/js/Makefile
@@ -5,7 +5,7 @@ all: build
 
 # called by node-gyp
 compile:
-	go build -buildmode=c-archive -o minify.a minify.go
+	go build -buildmode=c-archive -gcflags="-mmacosx-version-min=10.13" -o minify.a minify.go
 
 build:
 	go get -u all

--- a/bindings/js/Makefile
+++ b/bindings/js/Makefile
@@ -1,6 +1,12 @@
 SHELL=/usr/bin/env bash
 VERSION=`git describe --tags --abbrev=0 | cut -b 2-`
 
+# Below line is for Mac
+ifeq ($(shell uname -s),Darwin)
+export CGO_CFLAGS += -mmacosx-version-min=10.13
+export CGO_LDFLAGS += -mmacosx-version-min=10.13
+endif
+
 all: build
 
 # called by node-gyp

--- a/bindings/js/Makefile
+++ b/bindings/js/Makefile
@@ -5,7 +5,7 @@ all: build
 
 # called by node-gyp
 compile:
-	CGO_CFLAGS=-mmacosx-version-min=10.13 CGO_LDFLAGS=-mmacosx-version-min=10.13 go build -buildmode=c-archive -o minify.a minify.go
+	CGO_CFLAGS=-mmacosx-version-min=10.13 CGO_LDFLAGS=-mmacosx-version-min=10.13 GOARCH=amd64 go build -buildmode=c-archive -o minify.a minify.go
 
 build:
 	go get -u all

--- a/bindings/js/Makefile
+++ b/bindings/js/Makefile
@@ -5,7 +5,7 @@ all: build
 
 # called by node-gyp
 compile:
-	go build -buildmode=c-archive -gcflags="-mmacosx-version-min=10.13" -o minify.a minify.go
+	CGO_CFLAGS=-mmacosx-version-min=10.13 CGO_LDFLAGS=-mmacosx-version-min=10.13 go build -buildmode=c-archive -o minify.a minify.go
 
 build:
 	go get -u all

--- a/bindings/js/binding.gyp
+++ b/bindings/js/binding.gyp
@@ -2,7 +2,7 @@
     "targets": [{
         "target_name": "minify",
         "product_extension": "node",
-        "type": "<(library)",
+        "type": "loadable_module",
         "cflags": ["-Wall"],
         "sources": ["minify.c"],
         "libraries": ["../minify.a"],
@@ -11,7 +11,7 @@
             "message": "Building Go library...",
             "inputs": ["minify.go", "minify.c"],
             "outputs": ["minify.a"],
-            "action": ["make", "compile"],
+            "action": ["make", "compile"]
         }],
     }],
 }

--- a/bindings/js/binding.gyp
+++ b/bindings/js/binding.gyp
@@ -2,7 +2,7 @@
     "targets": [{
         "target_name": "minify",
         "product_extension": "node",
-        "type": "loadable_module",
+        "type": "<(library)",
         "cflags": ["-Wall"],
         "sources": ["minify.c"],
         "libraries": ["../minify.a"],
@@ -13,5 +13,18 @@
             "outputs": ["minify.a"],
             "action": ["make", "compile"]
         }],
+        "conditions": [
+          [
+            'OS=="mac"',
+            {
+              # node-gyp 2.x doesn't add this anymore
+              # https://github.com/TooTallNate/node-gyp/pull/612
+              "xcode_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++14",
+                "OTHER_LDFLAGS": ["-undefined dynamic_lookup"],
+              },
+            },
+          ]
+        ],
     }],
 }


### PR DESCRIPTION
Just tried out `v2.11.14` on `rollup-plugin-tdewolff-minify` but it is still failing on `macos` and on `windows`.
Personally I only ever intend to use this project in `linux`, but let's see if we can get this to build and run the tests at least on `macos`?