### PR TITLE
docker: Make container consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN /usr/bin/env bash -c make install
 FROM alpine:3
 
 COPY --from=build /go/bin/minify /usr/bin/minify
+COPY "containerfiles/container-entrypoint.sh" "/init.sh"
 
-ENTRYPOINT ["minify"]
-CMD ["--help"]
+ENTRYPOINT ["/init.sh"]

--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ See [CLI tool](https://github.com/tdewolff/minify/tree/master/cmd/minify) for in
 If you want to use Docker, please see https://hub.docker.com/r/tdewolff/minify.
 
 ```bash
-$ docker run -it tdewolff/minify
-/ # minify --version
+$ docker run -it tdewolff/minify --help
 ```
 
 ## API stability

--- a/cmd/minify/README.md
+++ b/cmd/minify/README.md
@@ -67,7 +67,7 @@ docker pull tdewolff/minify
 and run the image, for example in interactive mode:
 
 ```bash
-docker run -i --entrypoint "" tdewolff/minify sh -c 'echo "(function(){ if (a == false) { return 0; } else { return 1; } })();" | minify --type js'
+docker run -i tdewolff/minify sh -c 'echo "(function(){ if (a == false) { return 0; } else { return 1; } })();" | minify --type js'
 ```
 
 which will output

--- a/containerfiles/container-entrypoint.sh
+++ b/containerfiles/container-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2022 Olliver Schinagl <oliver@schinagl.nl>
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+CMD='minify'
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -le 0 ] || \
+   [ "${1#-}" != "${1}" ] || \
+   [ -d "${1}" ] || \
+   ! command -v "${1}" > '/dev/null' 2>&1; then
+	bin="${CMD}"
+fi
+
+exec ${bin:+${bin}} "${@}"
+
+exit 0


### PR DESCRIPTION
As per #387 the initial entry point might have been weird; but it worked just fine with CI systems. This was actually broken in the proposed fix in #389 making it actually worse (see the commit message). Docker 'recommends' to make sure containers are consistent. which this MR adds (using a script I have used in tons of containers to ensure consistency.

This should solve all problems, and makes the container work 'as if you are invoking the binary' if the container is run without any arguments, e.g. `docker run --rm -it tdewolff/minify` is the same as `minify` is run; any argument thus passed is also the same. Due to the whole 'consistency' thing, running it as `docker run --rm -it tdewolff/minify minify` also works, as you are launching a command in the container, just like `docker run --rm -it tdewolff/minify sh -c 'minify'` (or  `docker run --rm -it tdewolff/minify ls`) all just works.

This could open the possibility at some point to have an 'official' repo as we'd have this consistency bullet ticket.