### PR TITLE
CI: Push docker tags for various forms

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,10 @@
 name: Docker
 on:
   push:
+    branches:
+      - 'master'
     tags:
-      - 'v*'
+      - 'v*.*.*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,6 +17,14 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
+    - name: Generate container metadata
+      id: meta
+      uses: docker/metadata=action@v4
+      with:
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
     - name: Build and push
       uses: docker/build-push-action@v2
       with:


### PR DESCRIPTION
I have no idea if this works, so someone that understands docker's github actions needs to check this. I feel like there's things missing (names mostly from the tags) but it follows the examples/templates from docker itself [build-push-action][0] and [metadata-action][1].

[0]: https://github.com/docker/build-push-action
[1]: https://github.com/docker/metadata-action