### PR TITLE
test(bindings/js): unfix segfault

### DIFF
--- a/bindings/js/minify.go
+++ b/bindings/js/minify.go
@@ -166,7 +166,9 @@ func minifyFile(cmediatype, cinput, coutput *C.char) *C.char {
 
 //export minifyCleanup
 func minifyCleanup() {
-	os.Exit(0)
+	// This will fix the worker thread segfault test by explicitly ending the node
+	// process with a 0 signal
+	// os.Exit(0)
 }
 
 func main() {}

--- a/bindings/js/test/worker.js
+++ b/bindings/js/test/worker.js
@@ -19,6 +19,7 @@ if (isMainThread) {
         throw "unexpected output using worker threads: '"+output+"' instead of '"+expected+"'";
     }
     await worker.terminate();
+    console.log("success!"); // this needs to be printed
 } else {
     const { config, string } = await import('@tdewolff/minify');
     config({'html-keep-document-tags': true})


### PR DESCRIPTION
The `os.Exit(0)` call will terminate the node process completely and return a 0 status, making it seem like the test passed, but that will also prematurely terminate any running program...