### PR TITLE
Fix command for installing `minify` command to use v2 path.

### DIFF
--- a/cmd/minify/README.md
+++ b/cmd/minify/README.md
@@ -22,7 +22,7 @@ If you do not have `make`, instead run the following lines to install `minify` a
     go install ./cmd/minify
     source minify_bash_tab_completion
 
-Optionally, you can run `go install github.com/tdewolff/minify/cmd/minify@latest` to install the latest version.
+Optionally, you can run `go install github.com/tdewolff/minify/v2/cmd/minify@latest` to install the latest version.
 
 ### Arch Linux
 Using yay, see [AUR](https://aur.archlinux.org/packages/minify/)


### PR DESCRIPTION
This will install the correct, latest version.  If this is missing, version 2.3.6 is installed instead.