### PR TITLE
Fix incorrect permissions in Python bindings Workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   linux:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,9 +40,6 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
           CIBW_BEFORE_ALL: .ci/ensure-go.sh; cd bindings/py; go build -buildmode=c-shared -o src/minify/_minify.so
 
-      - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v0.1.14
-        if: startsWith(github.ref, 'refs/tags/')
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
See https://github.com/softprops/action-gh-release/issues/232. Previous workflow setup was working for pushes but not in our current setup with releases.