### PR TITLE
Fix target version for Python build

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux_2_28_i686
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
-          CIBW_BEFORE_ALL: .ci/ensure-go.sh; cd bindings/py; go build -buildmode=c-shared -o src/minify/_minify.so
+          CIBW_BEFORE_ALL: .ci/ensure-go.sh; cd bindings/py; go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}; go build -buildmode=c-shared -o src/minify/_minify.so
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -64,15 +64,9 @@ jobs:
         with:
           go-version: '>=1.17'
       - name: Fetch go package
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           cd bindings/py
           go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}
-      - name: Fetch go package
-        if: startsWith(github.ref, 'refs/tags/') == false
-        run: |
-          cd bindings/py
-          go get github.com/tdewolff/minify/v2@$(git describe --tags --abbrev=0)
       - name: Prebuild windows extension
         run: |
           sudo apt-get install mingw-w64
@@ -99,6 +93,13 @@ jobs:
           #  cibw_target: ARM64
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.17'
+      - name: Update version in go.mod
+        run: |
+          cd bindings/py
+          go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}
       - uses: actions/download-artifact@v3
         with:
           name: minify-windows-${{ matrix.go_target }}.so
@@ -137,15 +138,9 @@ jobs:
         with:
           go-version: '>=1.17'
       - name: Fetch go package
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           cd bindings/py
           go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}
-      - name: Fetch go package
-        if: startsWith(github.ref, 'refs/tags/') == false
-        run: |
-          cd bindings/py
-          go get github.com/tdewolff/minify/v2@$(git describe --tags --abbrev=0)
       - name: Prebuild macos extension
         run: |
           cd bindings/py
@@ -174,6 +169,13 @@ jobs:
           #  cibw_target: arm64
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.17'
+      - name: Update version in go.mod
+        run: |
+          cd bindings/py
+          go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}
       - uses: actions/download-artifact@v3
         with:
           name: minify-darwin-${{ matrix.go_target }}.so

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,7 +37,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux_2_28_i686
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
-          CIBW_BEFORE_ALL: .ci/ensure-go.sh; cd bindings/py; go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}; go build -buildmode=c-shared -o src/minify/_minify.so
+          CIBW_BEFORE_ALL: .ci/ensure-go.sh; cd bindings/py; go get github.com/tdewolff/minify/v2@${{ github.ref_name }}; go build -buildmode=c-shared -o src/minify/_minify.so
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -66,7 +66,7 @@ jobs:
       - name: Fetch go package
         run: |
           cd bindings/py
-          go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}
+          go get github.com/tdewolff/minify/v2@${{ github.ref_name }}
       - name: Prebuild windows extension
         run: |
           sudo apt-get install mingw-w64
@@ -99,7 +99,7 @@ jobs:
       - name: Update version in go.mod
         run: |
           cd bindings/py
-          go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}
+          go get github.com/tdewolff/minify/v2@${{ github.ref_name }}
       - uses: actions/download-artifact@v3
         with:
           name: minify-windows-${{ matrix.go_target }}.so
@@ -140,7 +140,7 @@ jobs:
       - name: Fetch go package
         run: |
           cd bindings/py
-          go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}
+          go get github.com/tdewolff/minify/v2@${{ github.ref_name }}
       - name: Prebuild macos extension
         run: |
           cd bindings/py
@@ -175,7 +175,7 @@ jobs:
       - name: Update version in go.mod
         run: |
           cd bindings/py
-          go get github.com/tdewolff/minify/v2@${GITHUB_REF#refs/tags/}
+          go get github.com/tdewolff/minify/v2@${{ github.ref_name }}
       - uses: actions/download-artifact@v3
         with:
           name: minify-darwin-${{ matrix.go_target }}.so

--- a/bindings/py/go.mod
+++ b/bindings/py/go.mod
@@ -3,6 +3,6 @@ module github.com/tdewolff/minify/bindings/py
 go 1.18
 
 require (
-	github.com/tdewolff/minify/v2 v2.12.9
-	github.com/tdewolff/parse/v2 v2.6.8
+	github.com/tdewolff/minify/v2 v2.20.3
+	github.com/tdewolff/parse/v2 v2.7.2
 )

--- a/bindings/py/go.sum
+++ b/bindings/py/go.sum
@@ -10,11 +10,16 @@ github.com/tdewolff/minify/v2 v2.12.2 h1:AKIoVwJj/HgBm+d/fPqpEZ31EtCM5FJfJNGagdR
 github.com/tdewolff/minify/v2 v2.12.2/go.mod h1:p5pwbvNs1ghbFED/ZW1towGsnnWwzvM8iz8l0eURi9g=
 github.com/tdewolff/minify/v2 v2.12.9 h1:dvn5MtmuQ/DFMwqf5j8QhEVpPX6fi3WGImhv8RUB4zA=
 github.com/tdewolff/minify/v2 v2.12.9/go.mod h1:qOqdlDfL+7v0/fyymB+OP497nIxJYSvX4MQWA8OoiXU=
+github.com/tdewolff/minify/v2 v2.20.3 h1:8x2BICr21IoNFda5EUyNsoNcEZHL/W0ap+sfUJiGdmg=
+github.com/tdewolff/minify/v2 v2.20.3/go.mod h1:AMF0J/eNujZLDbfMZvWweg5TSG/KuK+/UGKc+k1N8/w=
 github.com/tdewolff/parse/v2 v2.6.3 h1:O5rshbkaRmpRtD7k2lG65bEJpcfUMNg5Cx2uRKWVsI8=
 github.com/tdewolff/parse/v2 v2.6.3/go.mod h1:woz0cgbLwFdtbjJu8PIKxhW05KplTFQkOdX78o+Jgrs=
 github.com/tdewolff/parse/v2 v2.6.8 h1:mhNZXYCx//xG7Yq2e/kVLNZw4YfYmeHbhx+Zc0OvFMA=
 github.com/tdewolff/parse/v2 v2.6.8/go.mod h1:XHDhaU6IBgsryfdnpzUXBlT6leW/l25yrFBTEb4eIyM=
+github.com/tdewolff/parse/v2 v2.7.2 h1:9NdxF0nk/+lPI0YADDonSlpiY15hGcVUhXRj9hnK8sM=
+github.com/tdewolff/parse/v2 v2.7.2/go.mod h1:9p2qMIHpjRSTr1qnFxQr+igogyTUTlwvf9awHSm84h8=
 github.com/tdewolff/test v1.0.7 h1:8Vs0142DmPFW/bQeHRP3MV19m1gvndjUb1sn8yy74LM=
 github.com/tdewolff/test v1.0.7/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
 github.com/tdewolff/test v1.0.9/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
+github.com/tdewolff/test v1.0.10/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This endeavors to ensure we always have the latest go.mod to pull our Python version from. We could also do something with setuptools_scm to calculate Python version using the tags rather than looking at go.mod, but that runs the risk of getting out of sync.