### PR TITLE
Add keep-special-comments to bindings

### DIFF
--- a/bindings/js/minify.go
+++ b/bindings/js/minify.go
@@ -65,6 +65,8 @@ func minifyConfig(ckeys **C.char, cvals **C.char, length C.longlong) *C.char {
 			htmlMinifier.KeepComments, err = strconv.ParseBool(vals[i])
 		case "html-keep-conditional-comments":
 			htmlMinifier.KeepConditionalComments, err = strconv.ParseBool(vals[i])
+		case "html-keep-special-comments":
+			htmlMinifier.KeepSpecialComments, err = strconv.ParseBool(vals[i])
 		case "html-keep-default-attr-vals":
 			htmlMinifier.KeepDefaultAttrVals, err = strconv.ParseBool(vals[i])
 		case "html-keep-document-tags":

--- a/bindings/py/minify.go
+++ b/bindings/py/minify.go
@@ -65,6 +65,8 @@ func minifyConfig(ckeys **C.char, cvals **C.char, length C.longlong) *C.char {
 			htmlMinifier.KeepComments, err = strconv.ParseBool(vals[i])
 		case "html-keep-conditional-comments":
 			htmlMinifier.KeepConditionalComments, err = strconv.ParseBool(vals[i])
+		case "html-keep-special-comments":
+			htmlMinifier.KeepSpecialComments, err = strconv.ParseBool(vals[i])
 		case "html-keep-default-attr-vals":
 			htmlMinifier.KeepDefaultAttrVals, err = strconv.ParseBool(vals[i])
 		case "html-keep-document-tags":


### PR DESCRIPTION
Hello, thanks for the awesome library! 

**Description**:
`html-keep-conditional-comments` is getting deprecated, yet the bindings can't handle its replacement. This PR is just adding `html-keep-special-comments` to the bindings.

**Related issue**:
https://github.com/mrf345/flask_minify/issues/95