### PR TITLE
fix: js optional chaining with bracket notation #757

### DIFF
--- a/js/js.go
+++ b/js/js.go
@@ -1217,12 +1217,18 @@ func (m *jsMinifier) minifyExpr(i js.IExpr, prec js.OpPrec) {
 		} else {
 			m.minifyExpr(expr.X, js.OpMember)
 		}
+
+		// To address issue #757
+		isWrittenOptChainBytes := false
 		if expr.Optional {
 			m.write(optChainBytes)
+			isWrittenOptChainBytes = true
 		}
 		if lit, ok := expr.Y.(*js.LiteralExpr); ok && lit.TokenType == js.StringToken && 2 < len(lit.Data) {
 			if isIdent := js.AsIdentifierName(lit.Data[1 : len(lit.Data)-1]); isIdent {
-				m.write(dotBytes)
+				if !isWrittenOptChainBytes {
+					m.write(dotBytes)
+				}
 				m.write(lit.Data[1 : len(lit.Data)-1])
 				break
 			} else if isNum := js.AsDecimalLiteral(lit.Data[1 : len(lit.Data)-1]); isNum {

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -3,7 +3,6 @@ package js
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -679,6 +678,8 @@ func TestJS(t *testing.T) {
 		{`a=obj["3name"]`, `a=obj["3name"]`},
 		{"a=b`tmpl${a?b:b}tmpl`", "a=b`tmpl${a,b}tmpl`"},
 		{`a=b?.[c]`, `a=b?.[c]`},
+		{`a=b?.["c"]`, `a=b?.c`},         // Issue 757
+		{`a=b?.["c d"]`, `a=b?.["c d"]`}, // Issue 757
 		{`a=b.#c`, `a=b.#c`},
 		{`a=b().#c`, `a=b().#c`},
 		{`a=b?.#c`, `a=b?.#c`},
@@ -977,7 +978,7 @@ func TestRenamerIndices(t *testing.T) {
 
 func BenchmarkJQuery(b *testing.B) {
 	m := minify.New()
-	buf, err := ioutil.ReadFile("../benchmarks/sample_jquery.js")
+	buf, err := os.ReadFile("../benchmarks/sample_jquery.js")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The issue #757 occurs because both `m.write(optChainBytes)` and the branch inside `if isIdent := js.AsIdentifierName(lit.Data[1 : len(lit.Data)-1]); isIdent` call `m.write(dotBytes)`, which can result in writing two dots `..` simultaneously, causing an error.

The solution is to use an additional boolean variable to control and prevent writing two dots simultaneously. I have also added unit tests to verify this fix and replaced the deprecated `ioutil` package by `os`.