### PR TITLE
Docs: add debian and change command to apt

### DIFF
--- a/cmd/minify/README.md
+++ b/cmd/minify/README.md
@@ -47,10 +47,10 @@ Using Homebrew, see [Brew tap](https://github.com/tdewolff/homebrew-tap/)
 brew install tdewolff/tap/minify
 ```
 
-### Ubuntu
+### Debian / Ubuntu
 ```
-sudo apt-get update
-sudo apt-get install minify
+sudo apt update
+sudo apt install minify
 ```
 
 Note: may be outdated


### PR DESCRIPTION
minify cli readme had just ubuntu listed, but it's also available for debian for a long time.
- changed text to `Debian / Ubuntu` instead of `Ubuntu`
- changed the `apt-get` command to `apt` - this is available in debian since 2015 and ubuntu since 2016