### PR TITLE
css/css_test.go: fix incorrect test expectation

### DIFF
--- a/css/css_test.go
+++ b/css/css_test.go
@@ -143,7 +143,7 @@ func TestCSSInline(t *testing.T) {
 		{"color: hsla(400, 150%, 150%, 2);", "color:#fff"},
 		//{"color: hwb(0 0% 0%);", "color:red"}, TODO
 		//{"color: hwb(120 20% 20%/50%);", "color:"}, TODO
-		{"background-color:transparent", "background-color:initial"},
+		{"background-color:transparent", "background-color:transparent"},
 		{"background-position:top", "background-position:top"},
 		{"background-position:bottom", "background-position:bottom"},
 		{"background-position:center", "background-position:50%"},


### PR DESCRIPTION
addresses:

```
$ go test ./...
ok  	github.com/tdewolff/minify/v2	0.053s
?   	github.com/tdewolff/minify/v2/bindings/js	[no test files]
?   	github.com/tdewolff/minify/v2/bindings/py	[no test files]
ok  	github.com/tdewolff/minify/v2/cmd/minify	0.003s
--- FAIL: TestCSSInline (0.00s)
    --- FAIL: TestCSSInline/background-color:transparent (0.00s)
    css_test.go:438:438:
            background-color:transparent
            background-color:transparent
            background-color:initial
FAIL
FAIL	github.com/tdewolff/minify/v2/css	0.007s
ok  	github.com/tdewolff/minify/v2/html	0.006s
ok  	github.com/tdewolff/minify/v2/js	0.055s
ok  	github.com/tdewolff/minify/v2/json	0.003s
ok  	github.com/tdewolff/minify/v2/minify	0.002s
ok  	github.com/tdewolff/minify/v2/svg	0.005s
ok  	github.com/tdewolff/minify/v2/xml	0.003s
FAIL
```