### PR TITLE
css/css.go: fix `background-color:transparent` handling

### DIFF
--- a/css/css.go
+++ b/css/css.go
@@ -1140,7 +1140,7 @@ func (c *cssMinifier) minifyProperty(prop Hash, values []Token) []Token {
 		values[0] = minifyColor(values[0])
 	case Background_Color:
 		values[0] = minifyColor(values[0])
-		if c.o.Version == 0 {
+		if c.o.Version >= 3 {
 			if values[0].Ident == Transparent {
 				values[0].Data = initialBytes
 				values[0].Ident = Initial


### PR DESCRIPTION
addresses:

```
$ go test ./...
ok  	github.com/tdewolff/minify/v2	(cached)
?   	github.com/tdewolff/minify/v2/bindings/js	[no test files]
?   	github.com/tdewolff/minify/v2/bindings/py	[no test files]
ok  	github.com/tdewolff/minify/v2/cmd/minify	(cached)
--- FAIL: TestCSSInline (0.00s)
    --- FAIL: TestCSSInline/background-color:transparent (0.00s)
    css_test.go:438:438:
            background-color:transparent
            background-color:transparent
            background-color:initial
FAIL
FAIL	github.com/tdewolff/minify/v2/css	0.005s
ok  	github.com/tdewolff/minify/v2/html	(cached)
ok  	github.com/tdewolff/minify/v2/js	(cached)
ok  	github.com/tdewolff/minify/v2/json	(cached)
ok  	github.com/tdewolff/minify/v2/minify	(cached)
ok  	github.com/tdewolff/minify/v2/svg	(cached)
ok  	github.com/tdewolff/minify/v2/xml	(cached)
FAIL
```