### PR TITLE
Disable fail on warn for ci (node module)

### DIFF
--- a/bindings/js/tsdown.config.ts
+++ b/bindings/js/tsdown.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     platform: 'node',
     clean: true,
     dts: true,
-    format: ['esm', 'cjs']
+    format: ['esm', 'cjs'],
+    failOnWarn: false
 });


### PR DESCRIPTION
For some reason tsdown made it so by default it fails builds on any warning for ci, but not for local builds. Since this module allows for both ESM and CJS (best compatibility), its best to disable the failing on warnings option that tsdown provides.

Fixes the issue mentioned [here](https://github.com/tdewolff/minify/pull/879#issuecomment-3977354252)