### PR TITLE
Resolve #959. Add arm64 docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,27 +1,101 @@
 name: Docker
+
 on:
   push:
     tags:
-    - 'v*'
+      - 'v*'
+
+env:
+  IMAGE_NAME: tdewolff/minify
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            platform_pair: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            platform_pair: linux-arm64
+
+    runs-on: ${{ matrix.runner }}
+
     steps:
-    - uses: actions/checkout@v6
-    - uses: docker/metadata-action@v6
-      id: meta
-      with:
-        images: tdewolff/minify
-        tags: type=ref,event=tag
-    - uses: docker/login-action@v4
-      with:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-    - uses: docker/setup-buildx-action@v4
-    - uses: docker/build-push-action@v7
-      with:
-        context: .
-        file: ./Dockerfile
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      - uses: actions/checkout@v6
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/build-push-action@v7
+        id: build
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform_pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Create manifest list
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use this image to build the executable
-FROM golang:1.24-alpine AS build
+FROM golang:1.25-alpine AS build
 
 WORKDIR /go/src/github.com/tdewolff/minify
 COPY . /go/src/github.com/tdewolff/minify/


### PR DESCRIPTION
This PR adds parallel multiplatform docker images building process, with one more final step - combining and pushing multiarch docker manifest. Also, it upgrades base go docker imate to 1.25 version because of go update in commit 3f0aea9.

Just a bit more information.
1. Firstly I tried to use QEMU emulation for multiarch building directly via buildx. It works, but took significantly more times (about 4 minutes).
2. Current native platform building solution just adds about ~15sec to building (for the last manifest combining step).
3. Also it creates tiny temporarily Action artifacts (with images digest information from the multiplatform build steps) - they will be deleted after 1 day (minimal GitHub artifacts retention period).

Here you can see screenshots with successful docker build GitHub Action and pushed multiarchive docker images (on my accounts):
<img width="1244" height="445" alt="Screenshot 2026-04-25 at 22-43-36 avoid emulation for multiarch building · talkerbox_minify@eb71960" src="https://github.com/user-attachments/assets/418d1e57-d6a5-4d1b-adec-dee1e237b6cb" />
<img width="1319" height="277" alt="Screenshot 2026-04-25 at 23-08-38 talkerbox_minify tags" src="https://github.com/user-attachments/assets/8c0e9d2c-b21b-4b39-8e29-ef89eec5a8f6" />