### PR TITLE
shim in template begin and template end support for the cli

### DIFF
--- a/cmd/minify/main.go
+++ b/cmd/minify/main.go
@@ -237,6 +237,8 @@ func run() int {
 	f.AddOpt(&htmlMinifier.KeepWhitespace, "", "html-keep-whitespace", "Preserve whitespace characters but still collapse multiple into one")
 	f.AddOpt(&htmlMinifier.KeepQuotes, "", "html-keep-quotes", "Preserve quotes around attribute values")
 	//f.AddOpt(&htmlMinifier.TemplateDelims, "", "html-template-delims", "Set template delimiters explicitly, for example <?,?> for PHP or {{,}} for Go templates") // TODO: fix parsing {{ }} in tdewolff/argp
+	f.AddOpt(&htmlMinifier.TemplateBegin, "", "html-template-begin", "Set template open delimiters explicitly, for example <? for PHP or {{ for Go templates")
+	f.AddOpt(&htmlMinifier.TemplateEnd, "", "html-template-end", "Set template close delimiters explicitly, for example ?> for PHP or }} for Go templates")
 	f.AddOpt(&jsMinifier.Precision, "", "js-precision", "Number of significant digits to preserve in numbers, 0 is all")
 	f.AddOpt(&jsMinifier.KeepVarNames, "", "js-keep-var-names", "Preserve original variable names")
 	f.AddOpt(&jsMinifier.Version, "", "js-version", "ECMAScript version to toggle supported optimizations (e.g. 2019, 2020), by default 0 is the latest version")

--- a/html/html.go
+++ b/html/html.go
@@ -61,6 +61,8 @@ type Minifier struct {
 	KeepQuotes              bool
 	KeepWhitespace          bool
 	TemplateDelims          [2]string
+	TemplateBegin           string
+	TemplateEnd             string
 }
 
 // Minify minifies HTML data, it reads from r and writes to w.
@@ -87,6 +89,12 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, _ map[string]st
 
 	z := parse.NewInput(r)
 	defer z.Restore()
+
+	// shim to properly handle template delims if they have been passed via the cli
+	if o.TemplateDelims[0] == "" && o.TemplateDelims[1] == "" && o.TemplateBegin != "" && o.TemplateEnd != "" {
+		o.TemplateDelims[0] = o.TemplateBegin
+		o.TemplateDelims[1] = o.TemplateEnd
+	}
 
 	l := html.NewTemplateLexer(z, o.TemplateDelims)
 	tb := NewTokenBuffer(z, l)


### PR DESCRIPTION
Fix for issue #976 

Introduces 2 new command line args to allow cli users to set template delimiters

```
--html-template-begin
--html-template-end
```

which act as shims for the [2]TemplateDelims in the html minifier struct, specifically if they have been set, and TemplateDelims is empty, it will replace the values in the array. 

