### PR TITLE
JS: restore parse.Input buffer after minify

### DIFF
--- a/js/js.go
+++ b/js/js.go
@@ -39,6 +39,7 @@ func Minify(m *minify.M, w io.Writer, r io.Reader, params map[string]string) err
 // Minify minifies JS data, it reads from r and writes to w.
 func (o *Minifier) Minify(_ *minify.M, w io.Writer, r io.Reader, params map[string]string) error {
 	z := parse.NewInput(r)
+	defer z.Restore()
 	ast, err := js.Parse(z, js.Options{
 		WhileToFor: true,
 		Inline:     params != nil && params["inline"] == "1",


### PR DESCRIPTION
`parse.NewInputBytes` may write a temporary `0x00` past the end of the input when the slice has spare capacity, and relies on `Restore()` to put the original byte back. For example, when HTML minifies an embedded script, the closing `</script>` tag's `<` is set to `0x00`, and it would remain that way in the caller's buffer if not for `Restore()`.

CSS, HTML, JSON, SVG, and XML all call `defer z.Restore()`.

This PR adds the missing call to the `js` package as well.