### PR TITLE
XML/SVG: preserve whitespace character references in attribute values

### DIFF
--- a/svg/buffer.go
+++ b/svg/buffer.go
@@ -46,7 +46,7 @@ func (z *TokenBuffer) read(t *Token) {
 		if len(t.AttrVal) > 1 && (t.AttrVal[0] == '"' || t.AttrVal[0] == '\'') {
 			t.Offset++
 			t.AttrVal = t.AttrVal[1 : len(t.AttrVal)-1] // quotes will be readded in attribute loop if necessary
-			t.AttrVal = parse.ReplaceMultipleWhitespaceAndEntities(t.AttrVal, minifyXML.EntitiesMap, nil)
+			t.AttrVal = parse.ReplaceMultipleWhitespaceAndEntities(t.AttrVal, minifyXML.EntitiesMap, minifyXML.AttrRevEntitiesMap)
 			t.AttrVal = parse.TrimWhitespace(t.AttrVal)
 		}
 		t.Hash = ToHash(t.Text)

--- a/svg/svg_test.go
+++ b/svg/svg_test.go
@@ -35,6 +35,12 @@ func TestSVG(t *testing.T) {
 		{`<path x=""> </path>`, `<path x=""/>`},
 		{`<path x=" a "/>`, `<path x="a"/>`},
 		{"<path x=\" a \n b \"/>", `<path x="a b"/>`},
+		{`<path id="p&#9;q&#10;r&#13;s"/>`, `<path id="p&#9;q&#10;r&#13;s"/>`}, // keep whitespace refs, else normalization turns them to spaces
+		{`<path id="&#x9;&#xA;&#xD;"/>`, `<path id="&#9;&#10;&#13;"/>`},        // hex canonicalises to decimal
+		{`<path id="&#9;end"/>`, `<path id="&#9;end"/>`},                       // ref at value boundary is kept
+		{`<text>a&#9;b</text>`, "<text>a\tb</text>"},                           // text content is not normalized, decode stays
+		{`<path id="a&#9;&#9;b"/>`, `<path id="a&#9;&#9;b"/>`},                 // consecutive refs survive whitespace collapse
+		{`<path id="a  b"/>`, `<path id="a b"/>`},                              // literal whitespace still collapses
 		{`<path x="5.0px" y="0%"/>`, `<path x="5" y="0"/>`},
 		{`<svg viewBox="5.0px 5px 240IN px"><path/></svg>`, `<svg viewBox="5 5 240in px"><path/></svg>`},
 		{`<svg viewBox="5.0!5px"><path/></svg>`, `<svg viewBox="5!5px"><path/></svg>`},

--- a/xml/table.go
+++ b/xml/table.go
@@ -6,6 +6,14 @@ var EntitiesMap = map[string][]byte{
 	"quot": []byte("\""),
 }
 
+// AttrRevEntitiesMap keeps whitespace character references; decoding them to
+// literal tab/LF/CR would let attribute-value normalization collapse them to a space.
+var AttrRevEntitiesMap = map[byte][]byte{
+	'\t': []byte("&#9;"),
+	'\n': []byte("&#10;"),
+	'\r': []byte("&#13;"),
+}
+
 // TextRevEntitiesMap is a map of escapes.
 var TextRevEntitiesMap = map[byte][]byte{
 	'<': []byte("&lt;"),

--- a/xml/xml.go
+++ b/xml/xml.go
@@ -127,7 +127,7 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, _ map[string]st
 				w.Write(t.AttrVal)
 			} else {
 				val := t.AttrVal[1 : len(t.AttrVal)-1]
-				val = parse.ReplaceEntities(val, EntitiesMap, nil)
+				val = parse.ReplaceEntities(val, EntitiesMap, AttrRevEntitiesMap)
 				val = xml.EscapeAttrVal(&attrByteBuffer, val) // prefer single or double quotes depending on what occurs more often in value
 				w.Write(val)
 			}

--- a/xml/xml_test.go
+++ b/xml/xml_test.go
@@ -30,11 +30,16 @@ func TestXML(t *testing.T) {
 		{`<x a=a></x>`, `<x a=a/>`},
 		{`<x a=foo></x>`, `<x a=foo/>`},
 		{"<x a=\" a \n\r\t b \"/>", `<x a=" a     b "/>`},
+		{`<x a="p&#9;q&#10;r&#13;s"/>`, `<x a="p&#9;q&#10;r&#13;s"/>`}, // keep whitespace refs, else normalization turns them to spaces
+		{`<x a="&#09;&#0009;"/>`, `<x a="&#9;&#9;"/>`},                 // strip leading zeros
+		{`<x a="&#x9;&#xA;&#xd;"/>`, `<x a="&#9;&#10;&#13;"/>`},        // hex canonicalises to decimal
+		{`<x a="&#9;end"/>`, `<x a="&#9;end"/>`},                       // ref at value boundary is kept
 		{`<x a="&apos;b&quot;"></x>`, `<x a="'b&#34;"/>`},
 		{`<x a="&quot;&quot;'"></x>`, `<x a='""&#39;'/>`},
 		{`<x a="&amp;&lt;&gt;"></x>`, `<x a="&amp;&lt;&gt;"/>`},
 		{`<x>&amp;&lt;&gt;</x>`, `<x>&amp;&lt;&gt;</x>`},
 		{`<x>&#38;&#038;&#60;</x>`, `<x>&amp;&amp;&lt;</x>`},
+		{`<x>a&#9;b</x>`, "<x>a\tb</x>"}, // text content is not normalized, decode stays
 		{`<!DOCTYPE foo SYSTEM "Foo.dtd">`, `<!DOCTYPE foo SYSTEM "Foo.dtd">`},
 		{`text <!--comment--> text`, `text text`},
 		{"text\n<!--comment-->\ntext", "text\ntext"},


### PR DESCRIPTION
The XML and SVG minifiers decode whitespace character references (`&#9;`/`&#10;`/`&#13;` and hex forms) inside attribute values into literal tab/LF/CR. Under XML §3.3.3 attribute-value normalization a literal tab/LF/CR re-parses to a space while a character reference is preserved, so decoding silently corrupts the value:

| value | current output | after re-parse |
|---|---|---|
| `x&#9;y` | `x`+tab+`y` | `x y` (corrupted) |
| `x&#10;y` | `x`+LF+`y` | `x y` (corrupted) |
| `x&#13;y` | `x`+CR+`y` | `x y` (corrupted) |

The existing `{"<x a=\" a \n\r\t b \"/>", ...}` test already maps *literal* `\n\r\t` in an attribute to spaces — the same §3.3.3 rule — which is exactly why decoding a reference into that literal is wrong. The fix passes a reverse-entities map at the two attribute decode sites (`xml/xml.go`, `svg/buffer.go`) so the references are kept (hex canonicalises to the shorter decimal); text-content decoding, where `&#9;`→tab is correct, is left untouched. `go test ./xml/ ./svg/` passes, covering both minifiers, decimal/hex/leading-zero forms, value boundaries, and the literal-whitespace and text-content cases that must not regress.
