### PR TITLE
xml/svg: keep whitespace character references in text content

### DIFF
--- a/svg/svg.go
+++ b/svg/svg.go
@@ -96,7 +96,7 @@ func (o *Minifier) Minify(m *minify.M, w io.Writer, r io.Reader, params map[stri
 				w.Write(t.Data)
 			}
 		case xml.TextToken:
-			t.Data = parse.ReplaceMultipleWhitespaceAndEntities(t.Data, minifyXML.EntitiesMap, nil)
+			t.Data = parse.ReplaceMultipleWhitespaceAndEntities(t.Data, minifyXML.EntitiesMap, minifyXML.TextRevEntitiesMap)
 			t.Data = parse.TrimWhitespace(t.Data)
 
 			if tag == Style && len(t.Data) > 0 {

--- a/svg/svg_test.go
+++ b/svg/svg_test.go
@@ -38,7 +38,7 @@ func TestSVG(t *testing.T) {
 		{`<path id="p&#9;q&#10;r&#13;s"/>`, `<path id="p&#9;q&#10;r&#13;s"/>`}, // keep whitespace refs, else normalization turns them to spaces
 		{`<path id="&#x9;&#xA;&#xD;"/>`, `<path id="&#9;&#10;&#13;"/>`},        // hex canonicalises to decimal
 		{`<path id="&#9;end"/>`, `<path id="&#9;end"/>`},                       // ref at value boundary is kept
-		{`<text>a&#9;b</text>`, "<text>a\tb</text>"},                           // text content is not normalized, decode stays
+		{`<text>a&#9;b</text>`, `<text>a&#9;b</text>`},                         // keep whitespace refs in text, else normalization turns them to spaces
 		{`<path id="a&#9;&#9;b"/>`, `<path id="a&#9;&#9;b"/>`},                 // consecutive refs survive whitespace collapse
 		{`<path id="a  b"/>`, `<path id="a b"/>`},                              // literal whitespace still collapses
 		{`<path x="5.0px" y="0%"/>`, `<path x="5" y="0"/>`},

--- a/xml/table.go
+++ b/xml/table.go
@@ -14,9 +14,14 @@ var AttrRevEntitiesMap = map[byte][]byte{
 	'\r': []byte("&#13;"),
 }
 
-// TextRevEntitiesMap is a map of escapes.
+// TextRevEntitiesMap is a map of escapes. It keeps whitespace character
+// references; decoding them to literal tab/LF/CR would let text whitespace
+// normalization collapse them to a space.
 var TextRevEntitiesMap = map[byte][]byte{
-	'<': []byte("&lt;"),
-	'>': []byte("&gt;"),
-	'&': []byte("&amp;"),
+	'<':  []byte("&lt;"),
+	'>':  []byte("&gt;"),
+	'&':  []byte("&amp;"),
+	'\t': []byte("&#9;"),
+	'\n': []byte("&#10;"),
+	'\r': []byte("&#13;"),
 }

--- a/xml/xml_test.go
+++ b/xml/xml_test.go
@@ -39,7 +39,8 @@ func TestXML(t *testing.T) {
 		{`<x a="&amp;&lt;&gt;"></x>`, `<x a="&amp;&lt;&gt;"/>`},
 		{`<x>&amp;&lt;&gt;</x>`, `<x>&amp;&lt;&gt;</x>`},
 		{`<x>&#38;&#038;&#60;</x>`, `<x>&amp;&amp;&lt;</x>`},
-		{`<x>a&#9;b</x>`, "<x>a\tb</x>"}, // text content is not normalized, decode stays
+		{`<x>a&#9;b</x>`, `<x>a&#9;b</x>`},                         // keep whitespace refs in text, else normalization turns them to spaces
+		{`<x>p&#9;q&#10;r&#13;s</x>`, `<x>p&#9;q&#10;r&#13;s</x>`}, // same for LF and CR
 		{`<!DOCTYPE foo SYSTEM "Foo.dtd">`, `<!DOCTYPE foo SYSTEM "Foo.dtd">`},
 		{`text <!--comment--> text`, `text text`},
 		{"text\n<!--comment-->\ntext", "text\ntext"},


### PR DESCRIPTION
Fixes #1007.

In XML/SVG text content, a whitespace character reference like `&#9;` was decoded to a literal tab on minify, which the next minify pass then collapsed to a space — so `<x>a&#9;b</x>` → `<x>a\tb</x>` → `<x>a b</x>` (not idempotent).

`AttrRevEntitiesMap` already keeps these references for attribute values (#1006). This adds the same three entries (`&#9;`/`&#10;`/`&#13;`) to `TextRevEntitiesMap` and points the SVG text path at it (it was passing `nil`), so text content is consistent with attributes. Only explicit character references are affected — literal whitespace in text still normalizes as before (`a\tb` → `a b`).

`xml:space="preserve"` is a separate concern and isn't touched here.

Used AI assistance on this; I reviewed and tested it.
